### PR TITLE
Display list as list

### DIFF
--- a/staying-safe.qmd
+++ b/staying-safe.qmd
@@ -82,6 +82,7 @@ and follow the instructions.
 ### Toot privacy levels
 
 Four privacy levels exists for your toots:
+
 * Public
 * Unlisted, not visible on timeline
 * Private, visible only by followers


### PR DESCRIPTION
GitHub flavored markdown is finicky about need a blank line before the first list item.